### PR TITLE
Fix Operator Precedence Issue in isKey Method in newer ruby versions

### DIFF
--- a/lib/rodash.rb
+++ b/lib/rodash.rb
@@ -162,8 +162,9 @@ class Rodash
 
   def self.isKey(value, object)
     return true if value.is_a? Numeric
+
     return !value.is_a?(Array) &&
-      (@@reIsPlainProp =~ value || !@@reIsDeepProp =~ value ||
+      (@@reIsPlainProp =~ value || !(@@reIsDeepProp =~ value) ||
         (!object.nil? && !object.is_a?(Array) && object.has_key?(value)))
   end
 

--- a/lib/rodash.rb
+++ b/lib/rodash.rb
@@ -163,9 +163,11 @@ class Rodash
   def self.isKey(value, object)
     return true if value.is_a? Numeric
 
-    return !value.is_a?(Array) &&
-      (@@reIsPlainProp =~ value || !(@@reIsDeepProp =~ value) ||
-        (!object.nil? && !object.is_a?(Array) && object.has_key?(value)))
+    return false if value.is_a?(Array)
+
+    @@reIsPlainProp.match?(value) ||
+      !@@reIsDeepProp.match?(value) ||
+      (object && !object.is_a?(Array) && object.has_key?(value))
   end
 
   def self.baseToPath(value)


### PR DESCRIPTION
Updates the isKey method. The primary goal of these changes is to enhance readability and ensure compatibility with newer versions of Ruby.

**Key Changes:**

- Simplified the conditional logic without altering behavior.
- Method remains functionally consistent with previous Ruby versions while being compatible with newer releases.

**Tests before changes with different ruby versions**

- Passed on 2.7.8

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/b071f317-02e0-450a-9663-5d0c778ccb59)

- Warnings in 3.1.2

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/620a8775-8b73-4e9a-8275-68cca41702a1)

- Most test fail in 3.2.2

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/50833fff-71d7-45d6-a05b-c0afe1d94c60)

**Tests after changes**

- Passes in  2.7.8

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/90eed13f-35af-41ef-b51e-76556cfd7ef2)

- Passes in 3.1.2

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/006e52a4-c218-4beb-b3cb-d572b259f445)

- Passes in 3.2.2

![image](https://github.com/SINTEF-9012/Rodash/assets/2532265/63358dd8-4407-494b-b485-747e970a86a8)
